### PR TITLE
Fixes #8 Add support for connect(config) object argument; bump versio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,36 @@ easier.
 To initialize an sftp connection, simply include the package and then call `connect` with
 your server settings. Once connected, you can run the other methods (shown below).
 
+### Basic arguments config
+
 ```js
   const sftpa = require('sftp-async');
 
   await sftpa.connect('2.2.2.2', 22, 'username', 'password');
+
+  const dirlist = await sftpa.readdir('/upload');
+  const [file] = dirlist;
+  const content = await sftpa.getFileData(`/upload/${file.filename}`);
+
+  await sftpa.move(`/upload/${file.filename}`, `/processed/${file.filename}`);
+  await sftpa.disconnect();
+```
+
+### SSH2 connection config object
+
+https://github.com/mscdex/ssh2#client-methods
+
+```js
+  const sftpa = require('sftp-async');
+
+  const config = {
+	host: '2.2.2.2',
+	port: 22,
+	username: 'username',
+	password: 'password'
+  };
+
+  await sftpa.connect(config);
 
   const dirlist = await sftpa.readdir('/upload');
   const [file] = dirlist;

--- a/index.js
+++ b/index.js
@@ -5,12 +5,20 @@ const sftp = require('./lib/sftp');
 const o = {};
 
 const connect = async (host, port, username, password /* serverHostKey, kex */) => {
-  const connSettings = {
+  let connSettings = {
     host,
     port,
     username,
     password,
   };
+
+  // test for connection settings object in first argument
+  if (typeof(host) === 'object') {
+    connSettings = host;
+  }
+
+  // freeze `connSettings` to prevent further mutation
+  connSettings = Object.freeze(connSettings);
 
   try {
     if (o.connection) return o.connection;
@@ -18,7 +26,7 @@ const connect = async (host, port, username, password /* serverHostKey, kex */) 
     const [connection, client] = await sftp.connect(connSettings);
     o.connection = connection;
     o.client = client;
-  
+
     return o.connection;
   } catch (err) {
     throw new Error(err.message);

--- a/lib/sftp.js
+++ b/lib/sftp.js
@@ -30,7 +30,7 @@ const readdir = (sftp, dirPath) =>
   });
 
 const disconnect = (sftp, client) =>
-  new Promise(resolve => {  
+  new Promise(resolve => {
     sftp.end();
     client.end();
     resolve(true);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sftp-async",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sftp-async",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Asynchronous SFTP tools",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -3,10 +3,50 @@
 const sftp = require('../index');
 const config = require('./test.config');
 
-const start = async () => {
+const connectBasic = async () => {
   try {
     console.log('Connecting...');
     await sftp.connect(config.host, config.port, config.username, config.password);
+
+    console.log('Listing directory...');
+    const list = await sftp.readdir(config.sourcedir);
+    console.log(JSON.stringify(list, null, 2));
+
+    console.log('Getting file data');
+    const data = await sftp.getFileData(`${config.sourcedir}${list[0].filename}`);
+    console.log(data);
+
+    console.log('Moving file');
+    await sftp.move(
+      `${config.sourcedir}${list[0].filename}`,
+      `${config.destdir}${list[0].filename}`,
+    );
+    console.log('Moving it back');
+    console.log('Moving file');
+    await sftp.move(
+      `${config.destdir}${list[0].filename}`,
+      `${config.sourcedir}${list[0].filename}`,
+    );
+    console.log('Move OK');
+
+    console.log('Uploading file data');
+    await sftp.upload(`/upload/test.txt`, 'Hello world!');
+    console.log('Upload OK');
+
+    console.log('Uploading file using streams');
+    await sftp.streamToFtp(`/upload/test2.txt`, 'Hello world!');
+    console.log('Upload OK');
+  } catch (err) {
+    console.log(`Error!: ${err.message}`);
+    console.log(JSON.stringify(err, null, 2));
+  }
+  await sftp.disconnect();
+};
+
+const connectConfig = async () => {
+  try {
+    console.log('Connecting...');
+    await sftp.connect(config);
 
     console.log('Listing directory...');
     const list = await sftp.readdir(config.sourcedir);
@@ -60,7 +100,8 @@ const disconnectTimeout = async () => {
 };
 
 const runTests = async () => {
-  await start();
+  await connectBasic();
+  await connectConfig();
   await disconnectTimeout();
 }
 


### PR DESCRIPTION
…n to 1.1.0

I have added support for allowing a user to pass a single connection object similar to base usage of `ssh2.connect()` and other wrapper libraries, while maintaining backwards compatibility for passing in the original `connect(host, port, username, password)` arguments.